### PR TITLE
Corrected enabledProtocols and $stringafiedEnabledProtocols variable in xWebApplication

### DIFF
--- a/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
+++ b/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
@@ -268,7 +268,7 @@ function Set-TargetResource
                 # Make input bindings which are an array, into a string
                 $stringafiedEnabledProtocols = $EnabledProtocols -join ' '
                 Set-ItemProperty -Path "IIS:\Sites\$Website\$Name" `
-                                 -Name EnabledProtocols `
+                                 -Name enabledProtocols `
                                  -Value $stringafiedEnabledProtocols `
                                  -ErrorAction Stop
             }

--- a/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
+++ b/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
@@ -266,7 +266,7 @@ function Set-TargetResource
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetEnabledProtocols -f $Name)
                 # Make input bindings which are an array, into a string
-                $stringafiedEnabledProtocols = $EnabledProtocols -join ' '
+                $stringafiedEnabledProtocols = ($EnabledProtocols -join ' ') -replace '\s+',','
                 Set-ItemProperty -Path "IIS:\Sites\$Website\$Name" `
                                  -Name enabledProtocols `
                                  -Value $stringafiedEnabledProtocols `


### PR DESCRIPTION
The correct value for enabledProtocols is with a lowercase e. This mistake prevented the Set-ItemProperty from updating the enabled protocols on the web application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/295)
<!-- Reviewable:end -->
