### PR TITLE
xWebsite: Compare LogTruncateSize parameter correctly

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -489,7 +489,7 @@ function Set-TargetResource
 
             # Update LogTruncateSize if needed
             if ($PSBoundParameters.ContainsKey('LogTruncateSize') -and `
-                ($LogTruncateSize -ne $website.logfile.LogTruncateSize))
+                ($LogTruncateSize -ne $website.logfile.TruncateSize))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogTruncateSize `
                                         -f $Name)
@@ -737,7 +737,7 @@ function Set-TargetResource
 
             # Update LogTruncateSize if needed
             if ($PSBoundParameters.ContainsKey('LogTruncateSize') -and `
-                ($LogTruncateSize -ne $website.logfile.LogTruncateSize))
+                ($LogTruncateSize -ne $website.logfile.TruncateSize))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogTruncateSize `
                                         -f $Name)
@@ -1061,7 +1061,7 @@ function Test-TargetResource
 
         # Check LogTruncateSize
         if ($PSBoundParameters.ContainsKey('LogTruncateSize') -and `
-            ($LogTruncateSize -ne $website.logfile.LogTruncateSize))
+            ($LogTruncateSize -ne $website.logfile.TruncateSize))
         {
             Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseLogTruncateSize `
                                     -f $Name)

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 * Added **WebApplicationHandler** integration tests
 * Added **WebApplicationHandler** unit tests
 * Deprecated xIISHandler resource. This resource will be removed in future release
+* Fixed Test-TargetResource in xWebsite when LogTruncateSize parameter is passed; addresses [#380](https://github.com/PowerShell/xWebAdministration/issues/380). [Nick Germany (@nickgw)](https://github.com/nickgw)
 
 ### 2.0.0.0
 * Changes to xWebAdministration

--- a/README.md
+++ b/README.md
@@ -322,7 +322,8 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 * Added **WebApplicationHandler** integration tests
 * Added **WebApplicationHandler** unit tests
 * Deprecated xIISHandler resource. This resource will be removed in future release
-* Fixed Test-TargetResource in xWebsite when LogTruncateSize parameter is passed; addresses [#380](https://github.com/PowerShell/xWebAdministration/issues/380). [Nick Germany (@nickgw)](https://github.com/nickgw)
+* xWebsite
+  * Fixed Test-TargetResource in xWebsite when LogTruncateSize parameter is passed; addresses [#380](https://github.com/PowerShell/xWebAdministration/issues/380). [Nick Germany (@nickgw)](https://github.com/nickgw)
 
 ### 2.0.0.0
 * Changes to xWebAdministration


### PR DESCRIPTION
xWebsite attempts to compare the passed `$LogTruncateSize` to (essentially) `(Get-Website -Name $name).logFile.LogTruncateSize` except, the parameter is `truncatesize`. This causes the comparison to always fail.

Fixes #380

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/381)
<!-- Reviewable:end -->
