### PR TITLE
xWebSite: Revert back to Set-ItemProperty for LogFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - xWebsite
   - Fixed HTTPS binding issue causing failure when CertificateSubject matches
     multiple certificates.
+  - Fix an issue where changes to LogFlags would fail to apply.
+
 
 ## [3.1.0] - 2019-12-30
 

--- a/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
+++ b/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
@@ -585,11 +585,10 @@ function Set-TargetResource
             Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogFlags `
                                     -f $Name)
 
-            # Set-ItemProperty has no effect with the LogFile.LogExtFileFlags property
-            $site = Get-Item "IIS:\Sites\$Name"
-            $site.LogFile.LogFormat = 'W3C'
-            $site.LogFile.LogExtFileFlags = $LogFlags -join ','
-            $site | Set-Item
+            Set-ItemProperty "IIS:\Sites\$Name" `
+                -Name logFile.logFormat -value 'W3C'
+            Set-ItemProperty "IIS:\Sites\$Name" `
+                -Name logFile.logExtFileFlags -value ($LogFlags -join ',')
         }
 
         # Update LogPath if required

--- a/source/Examples/Resources/xIisLogging/Sample_xIisLogging_LogFlags.ps1
+++ b/source/Examples/Resources/xIisLogging/Sample_xIisLogging_LogFlags.ps1
@@ -1,0 +1,21 @@
+configuration Sample_xIisLogging_LogFlags
+{
+    param
+    (
+        # Target nodes to apply the configuration
+        [String[]] $NodeName = 'localhost'
+    )
+
+    # Import the module that defines custom resources
+    Import-DscResource -Module xWebAdministration
+
+    Node $NodeName
+    {
+        xIisLogging Logging
+        {
+            LogPath              = 'C:\IISLogFiles'
+            Logflags             = @('Date', 'Time', 'ClientIP', 'ServerIP', 'UserAgent')
+            LogFormat            = 'W3C'
+        }
+    }
+}

--- a/tests/Integration/MSFT_XIISLogging.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_XIISLogging.Integration.Tests.ps1
@@ -76,7 +76,7 @@ try
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion
-        It 'Changing Loggging Truncate Settings ' -test {
+        It 'Changing Logging Truncate Settings ' -test {
 
             Invoke-Expression -Command "$($script:dscResourceName)_Truncate -OutputPath `$TestDrive"
             Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
@@ -85,6 +85,41 @@ try
 
             $currentLogSettings.directory | Should Be 'C:\IISLogFiles'
             $currentLogSettings.logExtFileFlags | Should Be 'Date,Time,ClientIP,UserName,ServerIP'
+            $currentLogSettings.logformat | Should Be 'W3C'
+            $currentLogSettings.logTargetW3C | Should Be 'File,ETW'
+            $currentLogSettings.TruncateSize | Should Be '2097152'
+            $currentLogSettings.localTimeRollover | Should Be 'True'
+            $currentLogSettings.customFields.Collection[0].LogFieldName | Should Be 'ClientEncoding'
+            $currentLogSettings.customFields.Collection[0].SourceName | Should Be 'Accept-Encoding'
+            $currentLogSettings.customFields.Collection[0].SourceType | Should Be 'RequestHeader'
+            $currentLogSettings.customFields.Collection[1].LogFieldName | Should Be 'X-Powered-By'
+            $currentLogSettings.customFields.Collection[1].SourceName | Should Be 'ASP.NET'
+            $currentLogSettings.customFields.Collection[1].SourceType | Should Be 'ResponseHeader'
+        }
+    }
+
+    Describe "$($script:dscResourceName)_LogFlags" {
+        #region DEFAULT TESTS
+        It 'Should compile without throwing' {
+            {
+                Invoke-Expression -Command "$($script:dscResourceName)_LogFlags -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+        It 'Changing enabled LogFlags ' -test {
+
+            Invoke-Expression -Command "$($script:dscResourceName)_LogFlags -OutputPath `$TestDrive"
+            Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+
+            $currentLogSettings = Get-WebConfiguration -filter '/system.applicationHost/sites/siteDefaults/Logfile'
+
+            $currentLogSettings.directory | Should Be 'C:\IISLogFiles'
+            $currentLogSettings.logExtFileFlags | Should Be 'Date,Time,ClientIP,ServerIP,UserAgent'
             $currentLogSettings.logformat | Should Be 'W3C'
             $currentLogSettings.logTargetW3C | Should Be 'File,ETW'
             $currentLogSettings.TruncateSize | Should Be '2097152'

--- a/tests/Integration/MSFT_XIISLogging.config.ps1
+++ b/tests/Integration/MSFT_XIISLogging.config.ps1
@@ -55,3 +55,32 @@ configuration MSFT_xIisLogging_Truncate
         )
     }
 }
+
+configuration MSFT_xIisLogging_LogFlags
+{
+    Import-DscResource -ModuleName xWebAdministration
+
+    xIisLogging Logging
+    {
+        LogPath = 'C:\IISLogFiles'
+        Logflags = @('Date','Time','ClientIP','ServerIP','UserAgent')
+        LoglocalTimeRollover = $true
+        LogTruncateSize = '2097152'
+        LogFormat = 'W3C'
+        LogTargetW3C = 'File,ETW'
+        LogCustomFields    = @(
+            MSFT_xLogCustomField
+            {
+                LogFieldName = 'ClientEncoding'
+                SourceName   = 'Accept-Encoding'
+                SourceType   = 'RequestHeader'
+            }
+            MSFT_xLogCustomField
+            {
+                LogFieldName = 'X-Powered-By'
+                SourceName   = 'ASP.NET'
+                SourceType   = 'ResponseHeader'
+            }
+        )
+    }
+}

--- a/tests/Integration/MSFT_xWebSite.config.ps1
+++ b/tests/Integration/MSFT_xWebSite.config.ps1
@@ -72,6 +72,8 @@ configuration MSFT_xWebSite_Present_Started
             ServiceAutoStartProvider = $Node.ServiceAutoStartProvider
             State = 'Started'
             ServerAutoStart = $true
+            LogFlags = $Node.LogFlags1
+            LogFormat = $Node.LogFormat
             LogTargetW3C = 'ETW'
             LogCustomFields = @(
                 MSFT_xLogCustomFieldInformation
@@ -288,6 +290,8 @@ configuration MSFT_xWebSite_Webconfig_Get_Test_Set
             ServiceAutoStartEnabled = $Node.ServiceAutoStartEnabled
             ServiceAutoStartProvider = $Node.ServiceAutoStartProvider
             State = 'Started'
+            LogFlags = $Node.LogFlags1
+            LogFormat = $Node.LogFormat
             LogCustomFields = @(
                 MSFT_xLogCustomFieldInformation
                 {
@@ -302,6 +306,28 @@ configuration MSFT_xWebSite_Webconfig_Get_Test_Set
                     SourceType   = $Node.SourceType2
                 }
             )
+        }
+    }
+}
+
+configuration MSFT_xWebSite_Logging_Configured
+{
+    param(
+
+        [Parameter(Mandatory = $true)]
+        [String] $CertificateThumbprint
+
+    )
+
+    Import-DscResource -ModuleName xWebAdministration
+
+    Node $AllNodes.NodeName
+    {
+        xWebSite Website
+        {
+            Name      = $Node.Website
+            LogFlags  = $Node.LogFlags2
+            LogFormat = $Node.LogFormat
         }
     }
 }

--- a/tests/Integration/MSFT_xWebSite.config.psd1
+++ b/tests/Integration/MSFT_xWebSite.config.psd1
@@ -29,13 +29,16 @@
             HTTPSHostname               = 'https.website'
             CertificateStoreName        = 'MY'
             SslFlags                    = '1'
-            LogFieldName1                = 'CustomField1'
-            SourceName1                  = 'Accept-Encoding'
-            SourceType1                  = 'RequestHeader'
-            LogFieldName2                = 'CustomField2'
-            SourceName2                  = 'Warning'
-            SourceType2                  = 'ResponseHeader'
-            LogTargetW3C                 = 'ETW'
+            LogFieldName1               = 'CustomField1'
+            SourceName1                 = 'Accept-Encoding'
+            SourceType1                 = 'RequestHeader'
+            LogFieldName2               = 'CustomField2'
+            SourceName2                 = 'Warning'
+            SourceType2                 = 'ResponseHeader'
+            LogTargetW3C                = 'ETW'
+            LogFormat                   = 'W3C'
+            Logflags1                   = @('Date','Time','ClientIP','UserName','ServerIP')
+            Logflags2                   = @('Date','Time','ClientIP','ServerIP','UserAgent')
         }
     )
 }

--- a/tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -1124,9 +1124,9 @@ try
                     Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
                     Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
                     Assert-MockCalled -CommandName Set-Authentication -Exactly 4
-                    Assert-MockCalled -CommandName Get-Item -Exactly 3
-                    Assert-MockCalled -CommandName Set-Item -Exactly 3
-                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 11
+                    Assert-MockCalled -CommandName Get-Item -Exactly 2
+                    Assert-MockCalled -CommandName Set-Item -Exactly 2
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 13
                     Assert-MockCalled -CommandName Start-Website -Exactly 1
                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                     Assert-MockCalled -CommandName Test-LogCustomField -Exactly 1
@@ -1370,7 +1370,7 @@ try
                 Set-TargetResource @MockParameters
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 11
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 13
                     Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                     Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                     Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
@@ -1452,9 +1452,9 @@ try
                      Assert-MockCalled -CommandName Stop-Website -Exactly 1
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
-                     Assert-MockCalled -CommandName Get-Item -Exactly 1
-                     Assert-MockCalled -CommandName Set-Item -Exactly 1
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 8
+                     Assert-MockCalled -CommandName Get-Item -Exactly 0
+                     Assert-MockCalled -CommandName Set-Item -Exactly 0
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 10
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
                      Assert-MockCalled -CommandName Confirm-UniqueBinding -Exactly 1
@@ -1535,9 +1535,9 @@ try
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
-                     Assert-MockCalled -CommandName Get-Item -Exactly 2
-                     Assert-MockCalled -CommandName Set-Item -Exactly 2
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 6
+                     Assert-MockCalled -CommandName Get-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 8
                      Assert-MockCalled -CommandName Set-ItemProperty -ParameterFilter { $Name -eq 'LogFile.directory' } -Exactly 0
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
@@ -1617,9 +1617,9 @@ try
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
-                     Assert-MockCalled -CommandName Get-Item -Exactly 2
-                     Assert-MockCalled -CommandName Set-Item -Exactly 2
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 7
+                     Assert-MockCalled -CommandName Get-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 9
                      Assert-MockCalled -CommandName Set-ItemProperty -ParameterFilter { $Name -eq 'LogFile.directory' } -Exactly 1
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request reverts a change that was made in #300 which changed from using `Set-ItemProperty` to using `Set-Item`. This causes errors when run on **Windows Server 2016**, **IIS version 10.0** and fails to update `LogFlags`

Example of error:
```
Set-Item : Object reference not set to an instance of an object.
At line:1 char:9
+ $site | Set-Item
+         ~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-Item], NullReferenceException
    + FullyQualifiedErrorId : path,Microsoft.PowerShell.Commands.SetItemCommand
```

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xwebadministration/560)
<!-- Reviewable:end -->
