### PR TITLE
xWebSite: Taking the latest certificate when multiple has same subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 - xWebAdministration
   - Update GitVersion.yml with the correct regular expression.
+- xWebsite
+  - Fixed HTTPS binding issue causing failure when CertificateSubject matches
+    multiple certificates.
 
 ## [3.1.0] - 2019-12-30
 

--- a/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
+++ b/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
@@ -1474,7 +1474,7 @@ function ConvertTo-WebBinding
                     if ($FindCertificateSplat)
                     {
                         $FindCertificateSplat.Add('Store',$CertificateStoreName)
-                        $Certificate = Find-Certificate @FindCertificateSplat
+                        $Certificate = Find-Certificate @FindCertificateSplat | Select-Object -First 1
                         if ($Certificate)
                         {
                             $certificateHash = $Certificate.Thumbprint


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Fixes an issue with xWebsite where there are multiple certificates in the Cert Store with the same Subject. The existing behavior is faulty and returns an invalid concatenated thumbprint string. This fix ensures that we use the first certificate of the returned array (which is already sorted as the latest by the `Find-Certificate` function).

#### This Pull Request (PR) fixes the following issues
- Fixes #333
- Closes #334

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xwebadministration/561)
<!-- Reviewable:end -->
