### PR TITLE
xWebsite Inconsistent Logic in xWebsite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
     does not contain 'dsccommunity'.
   - Changed the VS Code project settings to trim trailing whitespace for
     markdown files too.
+  - Ensure that Test-TargetResourse in xWebSite tests all properties before
+    returning true or false, and that it uses a consistent style. ([issue #221](https://github.com/PowerShell/xWebAdministration/issues/550))
 
 ### Fixed
 

--- a/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
+++ b/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
@@ -818,7 +818,7 @@ function Test-TargetResource
         }
 
         # Check Physical Path property
-        if ([String]::IsNullOrEmpty($PhysicalPath) -eq $false -and `
+        if ($PSBoundParameters.ContainsKey('PhysicalPath') -and `
             $website.PhysicalPath -ne $PhysicalPath)
         {
             $inDesiredState = $false
@@ -827,7 +827,8 @@ function Test-TargetResource
         }
 
         # Check State
-        if ($PSBoundParameters.ContainsKey('State') -and $website.State -ne $State)
+        if ($PSBoundParameters.ContainsKey('State') -and `
+            $website.State -ne $State)
         {
             $inDesiredState = $false
             Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseState `
@@ -956,9 +957,9 @@ function Test-TargetResource
             # Check Log Format
             if ($LogFormat -ne $website.logfile.LogFormat)
             {
+                $inDesiredState = $false
                 Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogFormat `
                                         -f $Name)
-                return $false
             }
         }
 
@@ -966,17 +967,17 @@ function Test-TargetResource
         if ($PSBoundParameters.ContainsKey('LogFlags') -and `
             (-not (Compare-LogFlags -Name $Name -LogFlags $LogFlags)))
         {
+            $inDesiredState = $false
             Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogFlags)
-            return $false
         }
 
         # Check LogPath
         if ($PSBoundParameters.ContainsKey('LogPath') -and `
             ($LogPath -ne $website.logfile.directory))
         {
+            $inDesiredState = $false
             Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogPath `
                                     -f $Name)
-            return $false
         }
 
         # Check LogPeriod
@@ -988,19 +989,18 @@ function Test-TargetResource
                 Write-Verbose -Message ($script:localizedData.WarningLogPeriod `
                                         -f $Name)
             }
-
+            $inDesiredState = $false
             Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogPeriod `
                                     -f $Name)
-            return $false
         }
 
         # Check LogTruncateSize
         if ($PSBoundParameters.ContainsKey('LogTruncateSize') -and `
             ($LogTruncateSize -ne $website.logfile.LogTruncateSize))
         {
+            $inDesiredState = $false
             Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogTruncateSize `
                                     -f $Name)
-            return $false
         }
 
         # Check LoglocalTimeRollover
@@ -1008,27 +1008,27 @@ function Test-TargetResource
             ($LoglocalTimeRollover -ne `
             ([System.Convert]::ToBoolean($website.logfile.LocalTimeRollover))))
         {
+            $inDesiredState = $false
             Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLoglocalTimeRollover `
                                     -f $Name)
-            return $false
         }
 
         # Check LogTargetW3C
         if ($PSBoundParameters.ContainsKey('LogTargetW3C') -and `
             ($LogTargetW3C -ne $website.logfile.LogTargetW3C))
         {
+            $inDesiredState = $false
             Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogTargetW3C `
                                     -f $Name)
-            return $false
         }
 
         # Check LogCustomFields if needed
         if ($PSBoundParameters.ContainsKey('LogCustomFields') -and `
             (-not (Test-LogCustomField -Site $Name -LogCustomField $LogCustomFields)))
         {
+            $inDesiredState = $false
             Write-Verbose -Message ($script:localizedData.VerboseTestTargetUpdateLogCustomFields `
                                     -f $Name)
-            return $false
         }
     }
 


### PR DESCRIPTION

#### Pull Request (PR) description

The Test-TargetResource function in the xWebSite resource used
inconsistent logic in the way that it would test a property for
compliance and then report non-compliance.

Some tests would use the `$PSBoundParameters` variable to check for
parameters to be tested, others would use `[String]::isNullOrEmpty()`

Some tests would set the `$inDesiredState` variable, write a verbose
message and move on, and others would write the verbose message and
use the `return` keyward to immediately exit the function and stop
testing additional properties.

The desired style should use `$PSBoundParameters` and the
`$inDesiredState` variable consistently, so that all properties are
tested for troubleshooting purposes, and to promote conciseness and
reasability


#### This Pull Request (PR) fixes the following issues

Resolves #221

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xwebadministration/566)
<!-- Reviewable:end -->
