### PR TITLE
xIisLogging: Add Ensure property to LogCustomFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Changed the VS Code project settings to trim trailing whitespace for
     markdown files too.
   - Ensure that Test-TargetResourse in xWebSite tests all properties before
-    returning true or false, and that it uses a consistent style. ([issue #221](https://github.com/PowerShell/xWebAdministration/issues/550))   
+    returning true or false, and that it uses a consistent style. ([issue #221](https://github.com/PowerShell/xWebAdministration/issues/550))
 - xIisMimeTypeMapping
   - Update misleading localization strings
+- xIisLogging
+  - Add Ensure to LogCustomFields. ([issue #571](https://github.com/dsccommunity/xWebAdministration/issues/571))
 
 ### Fixed
 

--- a/source/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
+++ b/source/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
@@ -91,11 +91,11 @@ function Set-TargetResource
         [String] $LogPath,
 
         [Parameter()]
-        [ValidateSet('Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent','BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer','ProtocolVersion','Host','HttpSubStatus')]
+        [ValidateSet('Date', 'Time', 'ClientIP', 'UserName', 'SiteName', 'ComputerName', 'ServerIP', 'Method', 'UriStem', 'UriQuery', 'HttpStatus', 'Win32Status', 'BytesSent', 'BytesRecv', 'TimeTaken', 'ServerPort', 'UserAgent', 'Cookie', 'Referer', 'ProtocolVersion', 'Host', 'HttpSubStatus')]
         [String[]] $LogFlags,
 
         [Parameter()]
-        [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
+        [ValidateSet('Hourly', 'Daily', 'Weekly', 'Monthly', 'MaxSize')]
         [String] $LogPeriod,
 
         [Parameter()]
@@ -108,11 +108,11 @@ function Set-TargetResource
         [Boolean] $LoglocalTimeRollover,
 
         [Parameter()]
-        [ValidateSet('IIS','W3C','NCSA')]
+        [ValidateSet('IIS', 'W3C', 'NCSA')]
         [String] $LogFormat,
 
         [Parameter()]
-        [ValidateSet('File','ETW','File,ETW')]
+        [ValidateSet('File', 'ETW', 'File,ETW')]
         [String] $LogTargetW3C,
 
         [Parameter()]
@@ -120,97 +120,97 @@ function Set-TargetResource
         $LogCustomFields
     )
 
-        Assert-Module
+    Assert-Module
 
-        $currentLogState = Get-TargetResource -LogPath $LogPath
+    $currentLogState = Get-TargetResource -LogPath $LogPath
 
-        # Update LogFormat if needed
-        if ($PSBoundParameters.ContainsKey('LogFormat') -and `
-            ($LogFormat -ne $currentLogState.LogFormat))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogFormat)
-            Set-WebConfigurationProperty '/system.applicationHost/sites/siteDefaults/logfile' `
-                -Name logFormat `
-                -Value $LogFormat
-        }
-
-        # Update LogPath if needed
-        if ($PSBoundParameters.ContainsKey('LogPath') -and ($LogPath -ne $currentLogState.LogPath))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogPath)
-            Set-WebConfigurationProperty '/system.applicationHost/sites/siteDefaults/logfile' `
-                -Name directory `
-                -Value $LogPath
-        }
-
-        # Update Logflags if needed; also sets logformat to W3C
-        if ($PSBoundParameters.ContainsKey('LogFlags') -and `
-            (-not (Compare-LogFlags -LogFlags $LogFlags)))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogFlags)
-            Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
-                -Name logFormat `
-                -Value 'W3C'
-            Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
-                -Name logExtFileFlags `
-                -Value ($LogFlags -join ',')
-        }
-
-        # Update Log Period if needed
-        if ($PSBoundParameters.ContainsKey('LogPeriod') -and `
-            ($LogPeriod -ne $currentLogState.LogPeriod))
-        {
-            if ($PSBoundParameters.ContainsKey('LogTruncateSize'))
-                {
-                    Write-Verbose -Message ($script:localizedData.WarningLogPeriod)
-                }
-            Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogPeriod)
-            Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
-                -Name period `
-                -Value $LogPeriod
-        }
-
-        # Update LogTruncateSize if needed
-        if ($PSBoundParameters.ContainsKey('LogTruncateSize') -and `
-            ($LogTruncateSize -ne $currentLogState.LogTruncateSize))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogTruncateSize)
-            Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
-                -Name truncateSize `
-                -Value $LogTruncateSize
-            Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
-                -Name period `
-                -Value 'MaxSize'
-        }
-
-        # Update LoglocalTimeRollover if needed
-        if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
-            ($LoglocalTimeRollover -ne `
-             ([System.Convert]::ToBoolean($currentLogState.LoglocalTimeRollover))))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLoglocalTimeRollover)
-            Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
-                -Name localTimeRollover `
-                -Value $LoglocalTimeRollover
-        }
-
-        # Update LogTargetW3C if needed
-        if ($PSBoundParameters.ContainsKey('LogTargetW3C') -and `
-            ($LogTargetW3C -ne $currentLogState.LogTargetW3C))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogTargetW3C)
-            Set-WebConfigurationProperty '/system.applicationHost/sites/siteDefaults/logfile' `
-                -Name logTargetW3C `
-                -Value $LogTargetW3C
-        }
-
-         # Update LogCustomFields if neeed
-    if ($PSBoundParameters.ContainsKey('LogCustomFields') -and `
-         (-not (Test-LogCustomField -LogCustomField $LogCustomFields)))
+    # Update LogFormat if needed
+    if ($PSBoundParameters.ContainsKey('LogFormat') -and `
+        ($LogFormat -ne $currentLogState.LogFormat))
     {
-         Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogCustomFields)
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogFormat)
+        Set-WebConfigurationProperty '/system.applicationHost/sites/siteDefaults/logfile' `
+            -Name logFormat `
+            -Value $LogFormat
+    }
 
-         Set-LogCustomField -LogCustomField $LogCustomFields
+    # Update LogPath if needed
+    if ($PSBoundParameters.ContainsKey('LogPath') -and ($LogPath -ne $currentLogState.LogPath))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogPath)
+        Set-WebConfigurationProperty '/system.applicationHost/sites/siteDefaults/logfile' `
+            -Name directory `
+            -Value $LogPath
+    }
+
+    # Update Logflags if needed; also sets logformat to W3C
+    if ($PSBoundParameters.ContainsKey('LogFlags') -and `
+        (-not (Compare-LogFlags -LogFlags $LogFlags)))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogFlags)
+        Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
+            -Name logFormat `
+            -Value 'W3C'
+        Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
+            -Name logExtFileFlags `
+            -Value ($LogFlags -join ',')
+    }
+
+    # Update Log Period if needed
+    if ($PSBoundParameters.ContainsKey('LogPeriod') -and `
+        ($LogPeriod -ne $currentLogState.LogPeriod))
+    {
+        if ($PSBoundParameters.ContainsKey('LogTruncateSize'))
+        {
+            Write-Verbose -Message ($script:localizedData.WarningLogPeriod)
+        }
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogPeriod)
+        Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
+            -Name period `
+            -Value $LogPeriod
+    }
+
+    # Update LogTruncateSize if needed
+    if ($PSBoundParameters.ContainsKey('LogTruncateSize') -and `
+        ($LogTruncateSize -ne $currentLogState.LogTruncateSize))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogTruncateSize)
+        Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
+            -Name truncateSize `
+            -Value $LogTruncateSize
+        Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
+            -Name period `
+            -Value 'MaxSize'
+    }
+
+    # Update LoglocalTimeRollover if needed
+    if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
+        ($LoglocalTimeRollover -ne `
+            ([System.Convert]::ToBoolean($currentLogState.LoglocalTimeRollover))))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLoglocalTimeRollover)
+        Set-WebConfigurationProperty '/system.Applicationhost/Sites/SiteDefaults/logfile' `
+            -Name localTimeRollover `
+            -Value $LoglocalTimeRollover
+    }
+
+    # Update LogTargetW3C if needed
+    if ($PSBoundParameters.ContainsKey('LogTargetW3C') -and `
+        ($LogTargetW3C -ne $currentLogState.LogTargetW3C))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogTargetW3C)
+        Set-WebConfigurationProperty '/system.applicationHost/sites/siteDefaults/logfile' `
+            -Name logTargetW3C `
+            -Value $LogTargetW3C
+    }
+
+    # Update LogCustomFields if needed
+    if ($PSBoundParameters.ContainsKey('LogCustomFields') -and `
+        (-not (Test-LogCustomField -LogCustomField $LogCustomFields)))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetUpdateLogCustomFields)
+
+        Set-LogCustomField -LogCustomField $LogCustomFields
     }
 }
 
@@ -259,11 +259,11 @@ function Test-TargetResource
         [String] $LogPath,
 
         [Parameter()]
-        [ValidateSet('Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent','BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer','ProtocolVersion','Host','HttpSubStatus')]
+        [ValidateSet('Date', 'Time', 'ClientIP', 'UserName', 'SiteName', 'ComputerName', 'ServerIP', 'Method', 'UriStem', 'UriQuery', 'HttpStatus', 'Win32Status', 'BytesSent', 'BytesRecv', 'TimeTaken', 'ServerPort', 'UserAgent', 'Cookie', 'Referer', 'ProtocolVersion', 'Host', 'HttpSubStatus')]
         [String[]] $LogFlags,
 
         [Parameter()]
-        [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
+        [ValidateSet('Hourly', 'Daily', 'Weekly', 'Monthly', 'MaxSize')]
         [String] $LogPeriod,
 
         [Parameter()]
@@ -276,11 +276,11 @@ function Test-TargetResource
         [Boolean] $LoglocalTimeRollover,
 
         [Parameter()]
-        [ValidateSet('IIS','W3C','NCSA')]
+        [ValidateSet('IIS', 'W3C', 'NCSA')]
         [String] $LogFormat,
 
         [Parameter()]
-        [ValidateSet('File','ETW','File,ETW')]
+        [ValidateSet('File', 'ETW', 'File,ETW')]
         [String] $LogTargetW3C,
 
         [Parameter()]
@@ -288,98 +288,98 @@ function Test-TargetResource
         $LogCustomFields
     )
 
-        Assert-Module
+    Assert-Module
 
-        $currentLogState = Get-TargetResource -LogPath $LogPath
+    $currentLogState = Get-TargetResource -LogPath $LogPath
+
+    # Check LogFormat
+    if ($PSBoundParameters.ContainsKey('LogFormat'))
+    {
+        # Warn if LogFlags are passed in and Current LogFormat is not W3C
+        if ($PSBoundParameters.ContainsKey('LogFlags') -and `
+                $LogFormat -ne 'W3C')
+        {
+            Write-Verbose -Message ($script:localizedData.WarningIncorrectLogFormat)
+        }
+
+        # Warn if LogFlags are passed in and Desired LogFormat is not W3C
+        if ($PSBoundParameters.ContainsKey('LogFlags') -and `
+                $currentLogState.LogFormat -ne 'W3C')
+        {
+            Write-Verbose -Message ($script:localizedData.WarningIncorrectLogFormat)
+        }
 
         # Check LogFormat
-        if ($PSBoundParameters.ContainsKey('LogFormat'))
+        if ($LogFormat -ne $currentLogState.LogFormat)
         {
-            # Warn if LogFlags are passed in and Current LogFormat is not W3C
-            if ($PSBoundParameters.ContainsKey('LogFlags') -and `
-                $LogFormat -ne 'W3C')
-            {
-                Write-Verbose -Message ($script:localizedData.WarningIncorrectLogFormat)
-            }
-
-            # Warn if LogFlags are passed in and Desired LogFormat is not W3C
-            if ($PSBoundParameters.ContainsKey('LogFlags') -and `
-                $currentLogState.LogFormat -ne 'W3C')
-            {
-                Write-Verbose -Message ($script:localizedData.WarningIncorrectLogFormat)
-            }
-
-            # Check LogFormat
-            if ($LogFormat -ne $currentLogState.LogFormat)
-            {
-                Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogFormat)
-                return $false
-            }
-        }
-
-        # Check LogFlags
-        if ($PSBoundParameters.ContainsKey('LogFlags') -and `
-            (-not (Compare-LogFlags -LogFlags $LogFlags)))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogFlags)
+            Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogFormat)
             return $false
         }
+    }
 
-        # Check LogPath
-        if ($PSBoundParameters.ContainsKey('LogPath') -and `
-            ($LogPath -ne $currentLogState.LogPath))
+    # Check LogFlags
+    if ($PSBoundParameters.ContainsKey('LogFlags') -and `
+        (-not (Compare-LogFlags -LogFlags $LogFlags)))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogFlags)
+        return $false
+    }
+
+    # Check LogPath
+    if ($PSBoundParameters.ContainsKey('LogPath') -and `
+        ($LogPath -ne $currentLogState.LogPath))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogPath)
+        return $false
+    }
+
+    # Check LogPeriod
+    if ($PSBoundParameters.ContainsKey('LogPeriod') -and `
+        ($LogPeriod -ne $currentLogState.LogPeriod))
+    {
+        if ($PSBoundParameters.ContainsKey('LogTruncateSize'))
         {
-            Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogPath)
-            return $false
+            Write-Verbose -Message ($script:localizedData.WarningLogPeriod)
         }
 
-        # Check LogPeriod
-        if ($PSBoundParameters.ContainsKey('LogPeriod') -and `
-            ($LogPeriod -ne $currentLogState.LogPeriod))
-        {
-            if ($PSBoundParameters.ContainsKey('LogTruncateSize'))
-            {
-                Write-Verbose -Message ($script:localizedData.WarningLogPeriod)
-            }
+        Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogPeriod)
+        return $false
+    }
 
-            Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogPeriod)
-            return $false
-        }
+    # Check LogTruncateSize
+    if ($PSBoundParameters.ContainsKey('LogTruncateSize') -and `
+        ($LogTruncateSize -ne $currentLogState.LogTruncateSize))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogTruncateSize)
+        return $false
+    }
 
-        # Check LogTruncateSize
-        if ($PSBoundParameters.ContainsKey('LogTruncateSize') -and `
-            ($LogTruncateSize -ne $currentLogState.LogTruncateSize))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogTruncateSize)
-            return $false
-        }
+    # Check LoglocalTimeRollover
+    if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
+        ($LoglocalTimeRollover -ne `
+            ([System.Convert]::ToBoolean($currentLogState.LoglocalTimeRollover))))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLoglocalTimeRollover)
+        return $false
+    }
 
-        # Check LoglocalTimeRollover
-        if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
-            ($LoglocalTimeRollover -ne `
-             ([System.Convert]::ToBoolean($currentLogState.LoglocalTimeRollover))))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLoglocalTimeRollover)
-            return $false
-        }
+    # Check LogTargetW3C
+    if ($PSBoundParameters.ContainsKey('LogTargetW3C') -and `
+        ($LogTargetW3C -ne $currentLogState.LogTargetW3C))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogTargetW3C)
+        return $false
+    }
 
-        # Check LogTargetW3C
-        if ($PSBoundParameters.ContainsKey('LogTargetW3C') -and `
-            ($LogTargetW3C -ne $currentLogState.LogTargetW3C))
-        {
-            Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalseLogTargetW3C)
-            return $false
-        }
+    # Check LogCustomFields if needed
+    if ($PSBoundParameters.ContainsKey('LogCustomFields') -and `
+        (-not (Test-LogCustomField -LogCustomField $LogCustomFields)))
+    {
+        Write-Verbose -Message ($script:localizedData.VerboseTestTargetUpdateLogCustomFields)
+        return $false
+    }
 
-         # Check LogCustomFields if neeed
-        if ($PSBoundParameters.ContainsKey('LogCustomFields') -and `
-            (-not (Test-LogCustomField -LogCustomFields $LogCustomFields)))
-        {
-         Write-Verbose -Message ($script:localizedData.VerboseTestTargetUpdateLogCustomFields)
-         return $false
-        }
-
-        return $true
+    return $true
 
 }
 
@@ -400,19 +400,19 @@ function Compare-LogFlags
     param
     (
         [Parameter()]
-        [ValidateSet('Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent','BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer','ProtocolVersion','Host','HttpSubStatus')]
+        [ValidateSet('Date', 'Time', 'ClientIP', 'UserName', 'SiteName', 'ComputerName', 'ServerIP', 'Method', 'UriStem', 'UriQuery', 'HttpStatus', 'Win32Status', 'BytesSent', 'BytesRecv', 'TimeTaken', 'ServerPort', 'UserAgent', 'Cookie', 'Referer', 'ProtocolVersion', 'Host', 'HttpSubStatus')]
         [String[]] $LogFlags
     )
 
     $currentLogFlags = (Get-WebConfigurationProperty `
-                        -Filter '/system.Applicationhost/Sites/SiteDefaults/logfile' `
-                        -Name LogExtFileFlags) -split ',' | `
-                        Sort-Object
+        -Filter '/system.Applicationhost/Sites/SiteDefaults/logfile' `
+        -Name LogExtFileFlags) -split ',' | `
+        Sort-Object
 
     $proposedLogFlags = $LogFlags -split ',' | Sort-Object
 
     if (Compare-Object -ReferenceObject $currentLogFlags `
-                       -DifferenceObject $proposedLogFlags)
+        -DifferenceObject $proposedLogFlags)
     {
         return $false
     }
@@ -433,13 +433,13 @@ function ConvertTo-CimLogCustomFields
     [CmdletBinding()]
 
     [OutputType([Microsoft.Management.Infrastructure.CimInstance])]
-     param
-     (
+    param
+    (
         [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]
         [AllowNull()]
         [Object[]] $InputObject
-     )
+    )
 
     $cimClassName = 'MSFT_xLogCustomField'
     $cimNamespace = 'root/microsoft/Windows/DesiredStateConfiguration'
@@ -460,9 +460,9 @@ function ConvertTo-CimLogCustomFields
     }
 
     return $cimCollection
- }
+}
 
- <#
+<#
     .SYNOPSIS
         Helper function used to set the LogCustomField for a website.
 
@@ -485,10 +485,13 @@ function Set-LogCustomField
 
     foreach ($customField in $LogCustomField)
     {
-        $setCustomFields += @{
-            logFieldName = $customField.LogFieldName
-            sourceName   = $customField.SourceName
-            sourceType   = $customField.SourceType
+        if ($customField.Ensure -ne 'Absent')
+        {
+            $setCustomFields += @{
+                logFieldName = $customField.LogFieldName
+                sourceName   = $customField.SourceName
+                sourceType   = $customField.SourceType
+            }
         }
     }
 
@@ -518,29 +521,35 @@ function Test-LogCustomField
         $LogCustomFields
     )
 
-    $inDesiredSate = $true
+    $inDesiredState = $true
 
     foreach ($customField in $LogCustomFields)
     {
         $filterString = "/system.Applicationhost/Sites/SiteDefaults/logFile/customFields/add[@logFieldName='{0}']" -f $customField.LogFieldName
         $presentCustomField = Get-WebConfigurationProperty -Filter $filterString -Name "."
 
+        $shouldBePresent = $customField.Ensure -ne 'Absent'
+
         if ($presentCustomField)
         {
             $sourceNameMatch = $customField.SourceName -eq $presentCustomField.sourceName
             $sourceTypeMatch = $customField.SourceType -eq $presentCustomField.sourceType
-            if (-not ($sourceNameMatch -and $sourceTypeMatch))
+            $doesNotMatchEnsure = (-not ($sourceNameMatch -and $sourceTypeMatch)) -eq $shouldBePresent
+            if ($doesNotMatchEnsure)
             {
-                $inDesiredSate = $false
+                $inDesiredState = $false
             }
         }
         else
         {
-            $inDesiredSate = $false
+            if ($shouldBePresent)
+            {
+                $inDesiredState = $false
+            }
         }
     }
 
-    return $inDesiredSate
+    return $inDesiredState
 }
 
 #endregion

--- a/source/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.schema.mof
+++ b/source/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.schema.mof
@@ -17,4 +17,5 @@ class MSFT_xLogCustomField
     [Required, Description("Name for the custom field")] String LogFieldName;
     [Required, Description("Name for the source type")] String SourceName;
     [Required, Description("Specify the source type"), ValueMap{"RequestHeader","ResponseHeader","ServerVariable"},Values{"RequestHeader","ResponseHeader","ServerVariable"}] String SourceType;
+    [Write, Description("Indicates if the custom log field should be present or absent. Defaults to Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/tests/Unit/MSFT_xIISLogging.Tests.ps1
+++ b/tests/Unit/MSFT_xIISLogging.Tests.ps1
@@ -32,27 +32,27 @@ try
 {
     InModuleScope $script:dscResourceName {
 
-    $MockLogCustomFields = @{
+        $MockLogCustomFields = @{
             LogFieldName = 'ClientEncoding'
             SourceName   = 'Accept-Encoding'
             SourceType   = 'RequestHeader'
         }
 
-    $MockCimLogCustomFields = @(
-        New-CimInstance -ClassName MSFT_xLogCustomField `
-            -Namespace root/microsoft/Windows/DesiredStateConfiguration `
-            -Property @{
-                LogFieldName = 'ClientEncoding'
-                SourceName   = 'Accept-Encoding'
-                SourceType   = 'RequestHeader'
-            } `
-            -ClientOnly
-    )
+        $MockCimLogCustomFields = @(
+            New-CimInstance -ClassName MSFT_xLogCustomField `
+                -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                -Property @{
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'RequestHeader'
+                } `
+                -ClientOnly
+        )
 
-    $MockLogParameters =
+        $MockLogParameters =
         @{
             LogPath              = 'C:\MockLogLocation'
-            LogFlags             = 'Date','Time','ClientIP','UserName','ServerIP'
+            LogFlags             = 'Date', 'Time', 'ClientIP', 'UserName', 'ServerIP'
             LogPeriod            = 'Hourly'
             LogTruncateSize      = '2097152'
             LoglocalTimeRollover = $true
@@ -62,18 +62,18 @@ try
         }
 
         $MockLogOutput =
-            @{
-                directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                logExtFileFlags   = 'Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus'
-                logFormat         = 'W3C'
-                LogTargetW3C      = 'File,ETW'
-                period            = 'Daily'
-                truncateSize      = '1048576'
-                localTimeRollover = 'False'
-                customFields      = @{Collection = @($MockLogCustomFields)}
-            }
+        @{
+            directory         = '%SystemDrive%\inetpub\logs\LogFiles'
+            logExtFileFlags   = 'Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus'
+            logFormat         = 'W3C'
+            LogTargetW3C      = 'File,ETW'
+            period            = 'Daily'
+            truncateSize      = '1048576'
+            localTimeRollover = 'False'
+            customFields      = @{Collection = @($MockLogCustomFields) }
+        }
 
-        $MockLogFlagsAfterSplit = [System.String[]] @('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
+        $MockLogFlagsAfterSplit = [System.String[]] @('Date', 'Time', 'ClientIP', 'UserName', 'ServerIP', 'Method', 'UriStem', 'UriQuery', 'HttpStatus', 'Win32Status', 'TimeTaken', 'ServerPort', 'UserAgent', 'Referer', 'HttpSubStatus')
 
         Describe "$script:dscResourceName\Get-TargetResource" {
 
@@ -82,7 +82,7 @@ try
                 Mock -CommandName Get-WebConfiguration `
                     -MockWith { return $MockLogOutput }
 
-                Mock -CommandName Assert-Module -MockWith {}
+                Mock -CommandName Assert-Module -MockWith { }
 
                 Mock -CommandName ConvertTo-CimLogCustomFields `
                     -MockWith { return $MockLogCustomFields }
@@ -143,8 +143,8 @@ try
 
                 It 'Should return LogCustomFields' {
                     $result.LogCustomFields.LogFieldName | Should Be $MockLogCustomFields.LogFieldName
-                    $result.LogCustomFields.SourceName   | Should Be $MockLogCustomFields.SourceName
-                    $result.LogCustomFields.SourceType   | Should Be $MockLogCustomFields.SourceType
+                    $result.LogCustomFields.SourceName | Should Be $MockLogCustomFields.SourceName
+                    $result.LogCustomFields.SourceType | Should Be $MockLogCustomFields.SourceType
                 }
             }
 
@@ -152,9 +152,9 @@ try
 
         Describe "$script:dscResourceName\Test-TargetResource" {
 
-            Mock -CommandName Assert-Module -MockWith {}
+            Mock -CommandName Assert-Module -MockWith { }
 
-            Context 'All settings are correct'{
+            Context 'All settings are correct' {
 
                 $MockLogOutput =
                 @{
@@ -209,14 +209,14 @@ try
             Context 'Check LogPath should return false' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                    }
+                @{
+                    directory         = '%SystemDrive%\inetpub\logs\LogFiles'
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -237,14 +237,14 @@ try
             Context 'Check LogFlags should return false' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = 'Date', 'Time', 'ClientIP', 'UserName', 'ServerIP', 'Method', 'UriStem', 'UriQuery', 'HttpStatus', 'Win32Status', 'TimeTaken', 'ServerPort', 'UserAgent', 'Referer', 'HttpSubStatus'
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -265,14 +265,14 @@ try
             Context 'Check LogPeriod should return false' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = 'Daily'
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = 'Daily'
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -293,14 +293,14 @@ try
             Context 'Check LogTruncateSize should return false' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = '1048576'
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = '1048576'
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -329,14 +329,14 @@ try
                 }
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = '636870912'
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = '636870912'
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -357,14 +357,14 @@ try
             Context 'Check LoglocalTimeRollover should return false' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = 'False'
-                        logFormat         = $MockLogParameters.LogFormat
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = 'False'
+                    logFormat         = $MockLogParameters.LogFormat
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -385,14 +385,14 @@ try
             Context 'Check LogFormat should return false' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = 'IIS'
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = 'IIS'
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -413,15 +413,15 @@ try
             Context 'Check LogTargetW3C should return false' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                        LogTargetW3C      = 'File'
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                    LogTargetW3C      = 'File'
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -439,7 +439,7 @@ try
 
             }
 
-         Context 'Check LogCustomFields is equal' {
+            Context 'Check LogCustomFields is equal' {
                 #region Mocks for Test-TargetResource
                 Mock -CommandName Test-Path -MockWith { return $true }
                 Mock -CommandName Get-TargetResource -MockWith { return $MockLogParameters }
@@ -455,7 +455,7 @@ try
                 }
             }
 
-         Context 'Check LogCustomFields is different' {
+            Context 'Check LogCustomFields is different' {
                 $MockDifferentLogCustomFields = @{
                     LogFieldName = 'DifferentField'
                     SourceName   = 'Accept-Encoding'
@@ -480,20 +480,20 @@ try
 
         Describe "$script:dscResourceName\Set-TargetResource" {
 
-            Mock -CommandName Assert-Module -MockWith {}
+            Mock -CommandName Assert-Module -MockWith { }
 
             Context 'All Settings are incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                        logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
-                        logFormat         = 'IIS'
-                        logTargetW3C      = 'File'
-                        period            = 'Daily'
-                        truncateSize      = '1048576'
-                        localTimeRollover = 'False'
-                    }
+                @{
+                    directory         = '%SystemDrive%\inetpub\logs\LogFiles'
+                    logExtFileFlags   = 'Date', 'Time', 'ClientIP', 'UserName', 'ServerIP', 'Method', 'UriStem', 'UriQuery', 'HttpStatus', 'Win32Status', 'TimeTaken', 'ServerPort', 'UserAgent', 'Referer', 'HttpSubStatus'
+                    logFormat         = 'IIS'
+                    logTargetW3C      = 'File'
+                    period            = 'Daily'
+                    truncateSize      = '1048576'
+                    localTimeRollover = 'False'
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -508,7 +508,7 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 10
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 10
                 }
 
             }
@@ -516,15 +516,15 @@ try
             Context 'LogPath is incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                        logTargetW3C      = $MockLogParameters.LogTargetW3C
-                    }
+                @{
+                    directory         = '%SystemDrive%\inetpub\logs\LogFiles'
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                    logTargetW3C      = $MockLogParameters.LogTargetW3C
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -539,7 +539,7 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                 }
 
             }
@@ -547,15 +547,15 @@ try
             Context 'LogFlags are incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                        logTargetW3C      = $MockLogParameters.LogTargetW3C
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = 'Date', 'Time', 'ClientIP', 'UserName', 'ServerIP', 'Method', 'UriStem', 'UriQuery', 'HttpStatus', 'Win32Status', 'TimeTaken', 'ServerPort', 'UserAgent', 'Referer', 'HttpSubStatus'
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                    logTargetW3C      = $MockLogParameters.LogTargetW3C
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -570,7 +570,7 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 3
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 3
                 }
 
             }
@@ -578,15 +578,15 @@ try
             Context 'LogPeriod is incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = 'Daily'
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                        logTargetW3C      = $MockLogParameters.LogTargetW3C
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = 'Daily'
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                    logTargetW3C      = $MockLogParameters.LogTargetW3C
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -601,7 +601,7 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                 }
 
             }
@@ -609,15 +609,15 @@ try
             Context 'LogTruncateSize is incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = '1048576'
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                        logTargetW3C      = $MockLogParameters.LogTargetW3C
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = '1048576'
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                    logTargetW3C      = $MockLogParameters.LogTargetW3C
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -632,7 +632,7 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 3
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 3
                 }
 
             }
@@ -649,15 +649,15 @@ try
                     logTargetW3C         = $MockLogParameters.LogTargetW3C
                 }
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = '1048576'
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.LogFormat
-                        logTargetW3C      = $MockLogParameters.LogTargetW3C
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = '1048576'
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.LogFormat
+                    logTargetW3C      = $MockLogParameters.LogTargetW3C
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -672,7 +672,7 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                 }
 
                 It 'Should have the correct LogTruncateSize' {
@@ -684,15 +684,15 @@ try
             Context 'LoglocalTimeRollover is incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = 'False'
-                        logFormat         = $MockLogParameters.LogFormat
-                        logTargetW3C      = $MockLogParameters.LogTargetW3C
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = 'False'
+                    logFormat         = $MockLogParameters.LogFormat
+                    logTargetW3C      = $MockLogParameters.LogTargetW3C
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -707,7 +707,7 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                 }
 
             }
@@ -715,15 +715,15 @@ try
             Context 'LogFormat is incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = 'IIS'
-                        logTargetW3C      = $MockLogParameters.LogTargetW3C
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = 'IIS'
+                    logTargetW3C      = $MockLogParameters.LogTargetW3C
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -738,7 +738,7 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                 }
 
             }
@@ -746,15 +746,15 @@ try
             Context 'LogTargetW3C is incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                        logFormat         = $MockLogParameters.logFormat
-                        logTargetW3C      = 'File'
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                    logFormat         = $MockLogParameters.logFormat
+                    logTargetW3C      = 'File'
+                }
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -769,21 +769,21 @@ try
                 Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
-                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                 }
 
             }
 
         }
 
-    Describe "$script:dscResourceName\ConvertTo-CimLogCustomFields"{
+        Describe "$script:dscResourceName\ConvertTo-CimLogCustomFields" {
             $MockLogCustomFields = @{
                 LogFieldName = 'ClientEncoding'
                 SourceName   = 'Accept-Encoding'
                 SourceType   = 'RequestHeader'
             }
 
-             Context 'Expected behavior'{
+            Context 'Expected behavior' {
                 $Result = ConvertTo-CimLogCustomFields -InputObject $MockLogCustomFields
 
                 It 'Should return the LogFieldName' {
@@ -800,15 +800,39 @@ try
             }
         }
 
-    Describe "$script:dscResourceName\Test-LogCustomField" {
+        Describe "$script:dscResourceName\Test-LogCustomField" {
             $MockCimLogCustomFields = @(
                 New-CimInstance -ClassName MSFT_xLogCustomField `
                     -Namespace root/microsoft/Windows/DesiredStateConfiguration `
                     -Property @{
-                    LogFieldName = 'ClientEncoding'
-                    SourceName   = 'Accept-Encoding'
-                    SourceType   = 'RequestHeader'
-                } `
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                    } `
+                    -ClientOnly
+            )
+
+            $MockCimLogCustomFieldsEnsurePresentExplicitly = @(
+                New-CimInstance -ClassName MSFT_xLogCustomField `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                        Ensure       = 'Present'
+                    } `
+                    -ClientOnly
+            )
+
+            $MockCimLogCustomFieldsEnsureAbsent = @(
+                New-CimInstance -ClassName MSFT_xLogCustomField `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                        Ensure       = 'Absent'
+                    } `
                     -ClientOnly
             )
 
@@ -821,8 +845,17 @@ try
 
                 Mock -CommandName Get-WebConfigurationProperty -MockWith { return $MockDesiredLogCustomFields }
 
-                It 'Should return True' {
+                It 'Should return True with default Ensure (Present)' {
                     Test-LogCustomField -LogCustomField $MockCimLogCustomFields | Should Be $True
+                }
+
+                It 'Should return True with explicit Ensure Present' {
+                    Test-LogCustomField -LogCustomField $MockCimLogCustomFieldsEnsurePresentExplicitly | Should Be $True
+                }
+
+                It 'Should return True with Ensure Absent and Custom Field Absent' {
+                    Mock -CommandName Get-WebConfigurationProperty -MockWith { return $null }
+                    Test-LogCustomField -LogCustomField $MockCimLogCustomFieldsEnsureAbsent | Should Be $True
                 }
             }
 
@@ -835,15 +868,16 @@ try
 
                 Mock -CommandName Get-WebConfigurationProperty -MockWith { return $MockWrongLogCustomFields }
 
-                It 'Should return False' {
+                It 'Should return False with default Ensure (Present)' {
                     Test-LogCustomField -LogCustomField $MockCimLogCustomFields | Should Be $False
                 }
-            }
 
-            Context 'LogCustomField not present'{
-                Mock -CommandName Get-WebConfigurationProperty -MockWith { return $false }
+                It 'Should return False with explicit Ensure Present' {
+                    Test-LogCustomField -LogCustomField $MockCimLogCustomFieldsEnsurePresentExplicitly | Should Be $False
+                }
 
-                It 'Should return False' {
+                It 'Should return False with Ensure Present and Custom Field Absent' {
+                    Mock -CommandName Get-WebConfigurationProperty -MockWith { return $null }
                     Test-LogCustomField -LogCustomField $MockCimLogCustomFields | Should Be $False
                 }
             }
@@ -854,14 +888,14 @@ try
             Context 'Returns false when LogFlags are incorrect' {
 
                 $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = @('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
-                        logFormat         = 'W3C'
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                    }
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = @('Date', 'Time', 'ClientIP', 'UserName', 'ServerIP', 'Method', 'UriStem', 'UriQuery', 'HttpStatus', 'Win32Status', 'TimeTaken', 'ServerPort', 'UserAgent', 'Referer', 'HttpSubStatus')
+                    logFormat         = 'W3C'
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                }
 
                 Mock -CommandName Get-WebConfigurationProperty `
                     -MockWith { return $MockLogOutput.logExtFileFlags }
@@ -876,15 +910,15 @@ try
 
             Context 'Returns true when LogFlags are correct' {
 
-               $MockLogOutput =
-                    @{
-                        directory         = $MockLogParameters.LogPath
-                        logExtFileFlags   = $MockLogParameters.LogFlags
-                        logFormat         = 'W3C'
-                        period            = $MockLogParameters.LogPeriod
-                        truncateSize      = $MockLogParameters.LogTruncateSize
-                        localTimeRollover = $MockLogParameters.LoglocalTimeRollover
-                    }
+                $MockLogOutput =
+                @{
+                    directory         = $MockLogParameters.LogPath
+                    logExtFileFlags   = $MockLogParameters.LogFlags
+                    logFormat         = 'W3C'
+                    period            = $MockLogParameters.LogPeriod
+                    truncateSize      = $MockLogParameters.LogTruncateSize
+                    localTimeRollover = $MockLogParameters.LoglocalTimeRollover
+                }
 
                 Mock -CommandName Get-WebConfigurationProperty `
                     -MockWith { return $MockLogOutput.logExtFileFlags }
@@ -896,8 +930,8 @@ try
                 }
             }
 
-         }
-    Describe "$script:dscResourceName\Set-LogCustomField" {
+        }
+        Describe "$script:dscResourceName\Set-LogCustomField" {
 
             $MockCimLogCustomFields = @(
                 New-CimInstance -ClassName MSFT_xLogCustomField `
@@ -910,15 +944,47 @@ try
                     -ClientOnly
             )
 
+            $MockCimLogCustomFieldsEnsurePresentExplicitly = @(
+                New-CimInstance -ClassName MSFT_xLogCustomField `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                        Ensure       = 'Present'
+                    } `
+                    -ClientOnly
+            )
+
+            $MockCimLogCustomFieldsEnsureAbsent = @(
+                New-CimInstance -ClassName MSFT_xLogCustomField `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                        Ensure       = 'Absent'
+                    } `
+                    -ClientOnly
+            )
+
             Context 'Create new LogCustomField' {
                 Mock -CommandName Set-WebConfigurationProperty
 
-                It 'Should not throw an error' {
+                It 'Should not throw an error with default Ensure (Present)' {
                     { Set-LogCustomField  -LogCustomField $MockCimLogCustomFields } | Should Not Throw
                 }
 
-                It 'Should call should call expected mocks' {
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1
+                It 'Should not throw an error with explicit Ensure Present' {
+                    { Set-LogCustomField  -LogCustomField $MockCimLogCustomFieldsEnsurePresentExplicitly } | Should Not Throw
+                }
+
+                It 'Should not throw an error with Ensure Absent' {
+                    { Set-LogCustomField  -LogCustomField $MockCimLogCustomFieldsEnsureAbsent } | Should Not Throw
+                }
+
+                It 'Should call expected mocks' {
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 3
                 }
             }
 
@@ -926,12 +992,20 @@ try
             Context 'Modify existing LogCustomField' {
                 Mock -CommandName Set-WebConfigurationProperty
 
-                It 'Should not throw an error' {
-                    { Set-LogCustomField -LogCustomField $MockCimLogCustomFields } | Should Not Throw
+                It 'Should not throw an error with default Ensure (Present)' {
+                    { Set-LogCustomField  -LogCustomField $MockCimLogCustomFields } | Should Not Throw
                 }
 
-                It 'Should call should call expected mocks' {
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1
+                It 'Should not throw an error with explicit Ensure Present' {
+                    { Set-LogCustomField  -LogCustomField $MockCimLogCustomFieldsEnsurePresentExplicitly } | Should Not Throw
+                }
+
+                It 'Should not throw an error with Ensure Absent' {
+                    { Set-LogCustomField  -LogCustomField $MockCimLogCustomFieldsEnsureAbsent } | Should Not Throw
+                }
+
+                It 'Should call expected mocks' {
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 3
                 }
             }
         }


### PR DESCRIPTION
Run VSCode Powershell formatter

#### Pull Request (PR) description
- Add Ensure property to LogCustomFields to allow specification of 'Absent' for a custom log field.

#### This Pull Request (PR) fixes the following issues
- Fixes #571 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xwebadministration/572)
<!-- Reviewable:end -->
