### PR TITLE
xWebSite: skip certificate thumbprint and store name check when SslFlags are valid

### DIFF
--- a/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
+++ b/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
@@ -1435,6 +1435,8 @@ function ConvertTo-WebBinding
                 # SSL-related properties
                 if ($binding.Protocol -eq 'https')
                 {
+                    if ([Environment]::OSVersion.Version -lt '6.2' -or $binding.SslFlags -notin @('2', '3'))
+                    {
                     if ([String]::IsNullOrEmpty($binding.CertificateThumbprint))
                     {
                         if ($Binding.CertificateSubject)
@@ -1500,6 +1502,7 @@ function ConvertTo-WebBinding
 
                     $outputObject.Add('certificateHash',      [String]$certificateHash)
                     $outputObject.Add('certificateStoreName', [String]$certificateStoreName)
+                    }
 
                     if ([Environment]::OSVersion.Version -ge '6.2')
                     {


### PR DESCRIPTION
#### Pull Request (PR) description
SslFlags value 2 and 3 suggest the use of CCS (Central Certificate Store). Checking for certificate thumbprint and store name should be skipped when CCS is being used.

In IIS Management Console the **SSL certificate** field would be disabled when CCS is enabled.

#### This Pull Request (PR) fixes the following issues
Fixes #199 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
